### PR TITLE
Update geolexica-site.gemspec

### DIFF
--- a/geolexica-site.gemspec
+++ b/geolexica-site.gemspec
@@ -34,7 +34,7 @@ Gem::Specification.new do |spec|
   # Major dependencies.
   spec.add_runtime_dependency "geolexica-server", "~> 0.0.0"
   spec.add_runtime_dependency "jekyll", "~> 4.2.0"
-  spec.add_runtime_dependency "jekyll-geolexica", "~> 1.8.15"
+  spec.add_runtime_dependency "jekyll-geolexica", "~> 1.9.0"
 
   # Most useful Jekyll plugins.
   spec.add_runtime_dependency "jekyll-asciidoc", "~> 3.0.0"

--- a/geolexica-site.gemspec
+++ b/geolexica-site.gemspec
@@ -34,7 +34,7 @@ Gem::Specification.new do |spec|
   # Major dependencies.
   spec.add_runtime_dependency "geolexica-server", "~> 0.0.0"
   spec.add_runtime_dependency "jekyll", "~> 4.2.0"
-  spec.add_runtime_dependency "jekyll-geolexica", "~> 1.9.0"
+  spec.add_runtime_dependency "jekyll-geolexica", "~> 1.9.2"
 
   # Most useful Jekyll plugins.
   spec.add_runtime_dependency "jekyll-asciidoc", "~> 3.0.0"


### PR DESCRIPTION
Updated to use latest version of `Jekyll-geolexica` which now uses glossarist to read concept files.